### PR TITLE
 Disable the SBT JUnit XML reporter and suppress warnings from generated code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ lazy val playSettings: Seq[Setting[_]] = Seq.empty
 
 lazy val microservice = (project in file("."))
   .enablePlugins(plugins: _*)
+  .disablePlugins(JUnitXmlReportPlugin) //Required to prevent https://github.com/scalatest/scalatest/issues/1427
   .settings(playSettings: _*)
   .settings(scalaSettings: _*)
   .settings(publishingSettings: _*)
@@ -18,13 +19,19 @@ lazy val microservice = (project in file("."))
   .settings(PlayKeys.playDefaultPort := 9586)
   .settings(
     name := appName,
-    scalaVersion := "2.12.10",
+    scalaVersion := "2.12.12",
     targetJvm := "jvm-1.8",
     libraryDependencies ++= (AppDependencies.compile ++ AppDependencies.test).map(_ withSources()),
     evictionWarningOptions in update := EvictionWarningOptions.default.withWarnScalaVersionEviction(false),
     parallelExecution in Test := false,
     fork in Test := true,
-    retrieveManaged := true
+    retrieveManaged := true,
+    // Use the silencer plugin to suppress warnings from unused imports in compiled twirl templates
+    scalacOptions += "-P:silencer:pathFilters=views;routes",
+    libraryDependencies ++= Seq(
+      compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.1" cross CrossVersion.full),
+      "com.github.ghik" % "silencer-lib" % "1.7.1" % Provided cross CrossVersion.full
+    )
   )
   .settings(
     unmanagedSourceDirectories in Test := Seq(


### PR DESCRIPTION
Stops that issue with invalid JUnit XML when running Jenkins builds.

I also added the silencer plugin to suppress warnings from generated code like routes files and views.