### PR TITLE
DDCE-3656 Fix RulingRepo text filter on searches for Mongo 4.4

### DIFF
--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/audit/AuditService.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/audit/AuditService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/config/AppConfig.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/config/ErrorHandler.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/config/ErrorHandler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/config/Module.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/config/Module.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/AuthenticatedHttpClient.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/AuthenticatedHttpClient.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/BindingTariffClassificationConnector.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/BindingTariffClassificationConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/FileStoreConnector.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/FileStoreConnector.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/Application.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/Application.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/ApplicationType.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/ApplicationType.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/Attachment.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/Attachment.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/Case.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/Case.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/CaseStatus.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/CaseStatus.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/Decision.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/Decision.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/FileMetadata.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/FileMetadata.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/JsErrorResponse.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/connector/model/JsErrorResponse.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/AttachmentController.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/AttachmentController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/ImageController.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/ImageController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/RulingController.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/RulingController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/SearchController.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/SearchController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AdminAction.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AdminAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AllowListAction.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AllowListAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AuthenticatedAction.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AuthenticatedAction.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/forms/SimpleSearch.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/forms/SimpleSearch.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/filters/AllowListFilter.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/filters/AllowListFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/filters/RateLimitFilter.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/filters/RateLimitFilter.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/metrics/HasMetrics.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/metrics/HasMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/model/Paged.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/model/Paged.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/model/Pagination.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/model/Pagination.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/model/Ruling.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/model/Ruling.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/repository/RulingRepository.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/repository/RulingRepository.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,44 +49,44 @@ trait RulingRepository {
 
 //scalastyle:off magic.number
 @Singleton
-class RulingMongoRepository @Inject() (mongoComponent: MongoComponent)(implicit val ec: ExecutionContext)
-    extends PlayMongoRepository[Ruling](
-      collectionName = "rulings",
-      mongoComponent = mongoComponent,
-      domainFormat   = Ruling.Mongo.format,
-      indexes = Seq(
-        IndexModel(ascending("reference"), IndexOptions().unique(true).background(false).name("reference_Index")),
-        IndexModel(
-          ascending("bindingCommodityCode"),
-          IndexOptions().unique(false).background(false).name("bindingCommodityCode_Index")
+class RulingMongoRepository @Inject()(mongoComponent: MongoComponent)(implicit val ec: ExecutionContext)
+  extends PlayMongoRepository[Ruling](
+    collectionName = "rulings",
+    mongoComponent = mongoComponent,
+    domainFormat = Ruling.Mongo.format,
+    indexes = Seq(
+      IndexModel(ascending("reference"), IndexOptions().unique(true).background(false).name("reference_Index")),
+      IndexModel(
+        ascending("bindingCommodityCode"),
+        IndexOptions().unique(false).background(false).name("bindingCommodityCode_Index")
+      ),
+      IndexModel(
+        compoundIndex(
+          Indexes.text("reference"),
+          Indexes.text("bindingCommodityCode"),
+          Indexes.text("bindingCommodityCodeNGrams"),
+          Indexes.text("justification"),
+          Indexes.text("goodsDescription"),
+          Indexes.text("keywords")
         ),
-        IndexModel(
-          compoundIndex(
-            Indexes.text("reference"),
-            Indexes.text("bindingCommodityCode"),
-            Indexes.text("bindingCommodityCodeNGrams"),
-            Indexes.text("justification"),
-            Indexes.text("goodsDescription"),
-            Indexes.text("keywords")
-          ),
-          IndexOptions()
-            .unique(false)
-            .name("textIndex")
-            .background(false)
-            .weights(
-              BsonDocument("bindingCommodityCode" -> 10, "bindingCommodityCodeNgrams" -> 10, "keywords" -> 5)
-            )
-        )
+        IndexOptions()
+          .unique(false)
+          .name("textIndex")
+          .background(false)
+          .weights(
+            BsonDocument("bindingCommodityCode" -> 10, "bindingCommodityCodeNgrams" -> 10, "keywords" -> 5)
+          )
       )
     )
+  )
     with RulingRepository {
 
   override def update(ruling: Ruling, upsert: Boolean): Future[Ruling] =
     collection
       .findOneAndReplace(
-        filter      = byReference(ruling.reference),
+        filter = byReference(ruling.reference),
         replacement = ruling,
-        options     = FindOneAndReplaceOptions().upsert(true).returnDocument(ReturnDocument.AFTER)
+        options = FindOneAndReplaceOptions().upsert(true).returnDocument(ReturnDocument.AFTER)
       )
       .toFuture()
 
@@ -100,32 +100,41 @@ class RulingMongoRepository @Inject() (mongoComponent: MongoComponent)(implicit 
     collection.deleteMany(BsonDocument()).toFuture().map(_ => ())
 
   override def get(search: SimpleSearch): Future[Paged[Ruling]] = {
-    val startOfToday = LocalDate.now().atStartOfDay
-    val zoneOffset   = ZoneId.of("Europe/London").getRules.getOffset(startOfToday)
-    val today        = startOfToday.toInstant(zoneOffset)
 
-    val dateFilter  = Seq(Filters.gt("effectiveEndDate", today))
-    val textSearch  = search.query.map(query => Filters.text(query)).toSeq
+    val startOfToday = LocalDate.now().atStartOfDay
+    val zoneOffset = ZoneId.of("Europe/London").getRules.getOffset(startOfToday)
+    val today = startOfToday.toInstant(zoneOffset)
+
+    val textSearch = search.query.map(query => Filters.text(query)).toSeq
     val imageFilter = if (search.imagesOnly) Seq(Filters.gt("images", BsonArray())) else Seq.empty
+    val dateFilter = Seq(Filters.gt("effectiveEndDate", today))
 
     val allSearches: Seq[Bson] = textSearch ++ imageFilter ++ dateFilter
-    val findSearches           = if (allSearches.nonEmpty) and(allSearches: _*) else BsonDocument()
+    val findSearches = if (allSearches.nonEmpty) and(allSearches: _*) else BsonDocument()
 
     val textScore = if (search.query.isDefined) Sorts.metaTextScore("score") else BsonDocument()
 
-    for {
-      results <- collection
-                  .find(findSearches)
-                  .projection(Projections.metaTextScore("score"))
-                  .skip((search.pageIndex - 1) * search.pageSize)
-                  .limit(search.pageSize)
-                  .sort(Sorts.orderBy(textScore, descending("effectiveEndDate")))
-                  .toFuture()
+    val withOrWithoutProjectionSearch =
+      if (textSearch.isEmpty) {
+        collection
+          .find(findSearches)
+      } else {
+        collection
+          .find(findSearches)
+          .projection(Projections.metaTextScore("score"))
+      }
 
+    for {
+      results <-
+        withOrWithoutProjectionSearch
+          .skip((search.pageIndex - 1) * search.pageSize)
+          .limit(search.pageSize)
+          .sort(Sorts.orderBy(textScore, descending("effectiveEndDate")))
+          .toFuture()
       count <- collection
-                .withReadConcern(ReadConcern.MAJORITY)
-                .countDocuments(findSearches, CountOptions().skip(0))
-                .toFuture()
+        .withReadConcern(ReadConcern.MAJORITY)
+        .countDocuments(and(allSearches: _*), CountOptions().skip(0))
+        .toFuture()
     } yield Paged(results, search.pageIndex, search.pageSize, count)
   }
 

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/BackendScheduler.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/BackendScheduler.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/ScheduledJob.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/ScheduledJob.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/ScheduledJobFactory.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/ScheduledJobFactory.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/SchedulerJobs.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/SchedulerJobs.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/UpdateCanceledRulingsJob.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/UpdateCanceledRulingsJob.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/UpdateNewRulingsJob.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/scheduler/UpdateNewRulingsJob.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/service/FileStoreService.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/service/FileStoreService.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/utils/Dates.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/utils/Dates.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/utils/EnumJson.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/utils/EnumJson.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/utils/GlobalTariff.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/utils/GlobalTariff.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/PaginationUtil.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/PaginationUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/back_link.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/back_link.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/error_summary.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/error_summary.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/input_search.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/input_search.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/pagination.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/pagination.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/result_summary.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/result_summary.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/search_results.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/search_results.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/error.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/error.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/image.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/image.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/not_found.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/not_found.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/ruling.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/ruling.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/search.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/search.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@
   @errorSummary(form)
 
   @helper.form(action = routes.SearchController.get()) {
-@helper.CSRF.formField
+    @helper.CSRF.formField
     @searchInput(form)
   }
 

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/template/main_template.scala.html
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/views/template/main_template.scala.html
@@ -1,5 +1,5 @@
 @*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/uk/gov/hmrc/bindingtariffrulingfrontend/workers/RulingsWorker.scala
+++ b/app/uk/gov/hmrc/bindingtariffrulingfrontend/workers/RulingsWorker.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
-# Copyright 2022 HM Revenue & Customs
+# Copyright 2023 HM Revenue & Customs
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,15 +5,15 @@ object AppDependencies {
 
   val scope = "test"
 
-  private val hmrcMongoPlayVersion = "0.73.0"
+  private val hmrcMongoPlayVersion = "0.74.0"
   private val silencerVersion      = "1.7.12"
 
   val compile: Seq[ModuleID] = Seq(
-    "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28" % "7.11.0",
+    "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28" % "7.12.0",
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-28"         % hmrcMongoPlayVersion,
-    "uk.gov.hmrc"                  %% "play-json-union-formatter"  % "1.15.0-play-28",
+    "uk.gov.hmrc"                  %% "play-json-union-formatter"  % "1.17.0-play-28",
     "uk.gov.hmrc"                  %% "play-allowlist-filter"      % "1.1.0",
-    "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "3.32.0-play-28",
+    "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "5.5.0-play-28",
     "org.typelevel"                %% "cats-core"                  % "2.8.0",
     "com.digitaltangible"          %% "play-guard"                 % "2.5.0",
     "org.quartz-scheduler"         % "quartz"                      % "2.3.2",

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/audit/AuditServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/audit/AuditServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/base/BaseSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/base/BaseSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/config/AppConfigTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/config/AppConfigTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/connector/BindingTariffClassificationConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/connector/BindingTariffClassificationConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/connector/FileStoreConnectorSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/connector/FileStoreConnectorSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,15 +59,16 @@ class FileStoreConnectorSpec extends BaseSpec with WiremockTestServer {
           )
       )
 
-      await(connector.get("d4897c0a-b92d-4cf7-8990-f40fe158be68")) shouldBe Some(
-        FileMetadata(
-          "d4897c0a-b92d-4cf7-8990-f40fe158be68",
-          Some("IMG_1721.JPG"),
-          Some("image/jpeg"),
-          Some("http://localhost:4572/digital-tariffs-local/d4897c0a-b92d-4cf7-8990-f40fe158be68"),
-          published = true
+      await(connector.get("d4897c0a-b92d-4cf7-8990-f40fe158be68")) shouldBe
+        Some(
+          FileMetadata(
+            "d4897c0a-b92d-4cf7-8990-f40fe158be68",
+            Some("IMG_1721.JPG"),
+            Some("image/jpeg"),
+            Some("http://localhost:4572/digital-tariffs-local/d4897c0a-b92d-4cf7-8990-f40fe158be68"),
+            published = true
+          )
         )
-      )
     }
 
     "call the filestore for multiple IDs" in {
@@ -90,7 +91,7 @@ class FileStoreConnectorSpec extends BaseSpec with WiremockTestServer {
             "9a7a1787-4ec1-40d7-aa75-50cb276e3d28"
           )
         )
-      ) shouldBe (
+      ) shouldBe
         Map(
           "006491c2-a60b-46cc-9e73-5e180d3bf1ce" -> FileMetadata(
             "006491c2-a60b-46cc-9e73-5e180d3bf1ce",
@@ -107,11 +108,10 @@ class FileStoreConnectorSpec extends BaseSpec with WiremockTestServer {
             published = true
           )
         )
-      )
-
     }
 
     "download a file from the given URL" in {
+
       val content = "Some content".getBytes(StandardCharsets.UTF_8)
 
       stubFor(

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/AttachmentControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/AttachmentControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/ControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/ControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/ImageControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/ImageControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/RulingControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/RulingControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/SearchControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/SearchControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AdminActionSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AdminActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AdminDisabled.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AdminDisabled.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AdminEnabled.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AdminEnabled.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AllowListActionSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AllowListActionSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AllowListDisabled.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AllowListDisabled.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AllowListEnabled.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AllowListEnabled.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AuthenticatedActionTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/AuthenticatedActionTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/FailedAuth.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/FailedAuth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/SuccessfulAuth.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/action/SuccessfulAuth.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/forms/SimpleSearchSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/controllers/forms/SimpleSearchSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/metrics/HasMetricsSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/metrics/HasMetricsSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/model/PagedTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/model/PagedTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/model/RulingTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/model/RulingTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/repository/RulingMongoRepositoryTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/repository/RulingMongoRepositoryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,30 +29,28 @@ import java.time._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 //scalastyle:off magic.number
-class RulingMongoRepositoryTest
-    extends AnyWordSpecLike
-    with GuiceOneAppPerSuite
-    with Matchers
-    with DefaultPlayMongoRepositorySupport[Ruling] {
+class RulingMongoRepositoryTest extends AnyWordSpecLike with GuiceOneAppPerSuite
+  with Matchers with DefaultPlayMongoRepositorySupport[Ruling] {
 
   private val clock = Clock.tickSeconds(ZoneOffset.UTC)
 
   override protected lazy val repository: RulingMongoRepository = new RulingMongoRepository(mongoComponent)
 
-  lazy val readConcern: ReadConcern                 = ReadConcern.MAJORITY
+  lazy val readConcern: ReadConcern = ReadConcern.MAJORITY
+
   protected def collection: MongoCollection[Ruling] = repository.collection
 
   val startOfToday: LocalDateTime = LocalDate.now().atStartOfDay
   val zoneOffsetToday: ZoneOffset = ZoneId.of("Europe/London").getRules.getOffset(startOfToday)
-  val today: Instant              = startOfToday.toInstant(zoneOffsetToday)
+  val today: Instant = startOfToday.toInstant(zoneOffsetToday)
 
-  val startOfTomorrow: LocalDateTime  = LocalDate.now().plusDays(1).atStartOfDay
+  val startOfTomorrow: LocalDateTime = LocalDate.now().plusDays(1).atStartOfDay
   val startOfNextMonth: LocalDateTime = LocalDate.now().plusMonths(1).atStartOfDay
 
-  val zoneOffsetTomorrow: ZoneOffset  = ZoneId.of("Europe/London").getRules.getOffset(startOfTomorrow)
+  val zoneOffsetTomorrow: ZoneOffset = ZoneId.of("Europe/London").getRules.getOffset(startOfTomorrow)
   val zoneOffsetNextMonth: ZoneOffset = ZoneId.of("Europe/London").getRules.getOffset(startOfNextMonth)
 
-  val tomorrow: Instant  = startOfTomorrow.toInstant(zoneOffsetTomorrow)
+  val tomorrow: Instant = startOfTomorrow.toInstant(zoneOffsetTomorrow)
   val nextMonth: Instant = startOfNextMonth.toInstant(zoneOffsetNextMonth)
 
   override def beforeEach(): Unit = {
@@ -65,7 +63,14 @@ class RulingMongoRepositoryTest
     await(repository.collection.drop().toFuture())
   }
 
+  private def givenAnExistingDocument(ruling: Ruling): Unit =
+    await(repository.update(ruling, upsert = true))
+
+  private def thenTheDocumentCountShouldBe(count: Int): Unit =
+    await(repository.collection.countDocuments().toFuture()) shouldBe count
+
   "Update" should {
+
     "Update One" in {
       val document = Ruling(reference = "ref", "code", clock.instant(), tomorrow, "justification", "description")
       givenAnExistingDocument(document)
@@ -77,6 +82,7 @@ class RulingMongoRepositoryTest
   }
 
   "Delete by Reference" should {
+
     "Delete One" in {
       givenAnExistingDocument(
         Ruling(reference = "ref1", "code", clock.instant(), tomorrow, "justification", "description")
@@ -86,12 +92,12 @@ class RulingMongoRepositoryTest
       )
 
       await(repository.delete("ref1"))
-
       thenTheDocumentCountShouldBe(1)
     }
   }
 
   "Delete Many" should {
+
     "Delete All" in {
       givenAnExistingDocument(
         Ruling(reference = "ref1", "code", clock.instant(), tomorrow, "justification", "description")
@@ -107,12 +113,12 @@ class RulingMongoRepositoryTest
   }
 
   "Get by Reference" should {
+
     "Retrieve None" in {
       await(repository.get("some id")) shouldBe None
     }
 
     "Retrieve One" in {
-      // Given
       val document = Ruling(reference = "ref", "code", clock.instant(), tomorrow, "justification", "description")
       givenAnExistingDocument(document)
 
@@ -121,12 +127,12 @@ class RulingMongoRepositoryTest
   }
 
   "Get by SimpleSearch" should {
+
     "Retrieve None" in {
       await(repository.get(SimpleSearch(Some("ref"), imagesOnly = false, 1, 100))).results shouldBe Seq.empty
     }
 
     "Retrieve Multiple - no query" in {
-      // Given
       val document1 = Ruling(reference = "ref1", "0", clock.instant(), tomorrow, "justification", "exacting")
       val document2 = Ruling(reference = "ref2", "0", clock.instant(), tomorrow, "justification", "exactly")
       val document3 = Ruling(reference = "ref3", "0", clock.instant(), tomorrow, "justification", "fountain pen")
@@ -138,8 +144,19 @@ class RulingMongoRepositoryTest
       result should contain theSameElementsAs Seq(document1, document2, document3)
     }
 
+    "Sort Rulings based on effectiveEndDate - latest end date first, earliest end date last" in {
+      val document1 = Ruling(reference = "ref1", "0", clock.instant(), tomorrow.plusSeconds(2), "justification", "exacting")
+      val document2 = Ruling(reference = "ref2", "0", clock.instant(), tomorrow.plusSeconds(1), "justification", "exactly")
+      val document3 = Ruling(reference = "ref3", "0", clock.instant(), tomorrow.plusSeconds(3), "justification", "fountain pen")
+      givenAnExistingDocument(document1)
+      givenAnExistingDocument(document2)
+      givenAnExistingDocument(document3)
+
+      val result = await(repository.get(SimpleSearch(Some("0"), imagesOnly = false, 1, 100))).results
+      result shouldBe Seq(document3, document1, document2)
+    }
+
     "Retrieve One - by Reference - exact match" in {
-      // Given
       val document1 = Ruling(reference = "ref1", "0", clock.instant(), tomorrow, "justification", "description")
       val document2 = Ruling(reference = "ref11", "0", clock.instant(), tomorrow, "justification", "description")
       givenAnExistingDocument(document1)
@@ -149,7 +166,6 @@ class RulingMongoRepositoryTest
     }
 
     "Retrieve One - by Commodity Code - starts with" in {
-      // Given
       val document1 = Ruling(reference = "ref1", "00", clock.instant(), tomorrow, "justification", "description")
       val document2 = Ruling(reference = "ref2", "10", clock.instant(), tomorrow, "justification", "description")
       givenAnExistingDocument(document1)
@@ -159,18 +175,16 @@ class RulingMongoRepositoryTest
     }
 
     "Retrieve One - by Goods Description - case insensitive" in {
-      // Given
       val document1 = Ruling(reference = "ref1", "0", clock.instant(), tomorrow, "justification", "fountain pen")
       val document2 = Ruling(reference = "ref2", "0", clock.instant(), tomorrow, "justification", "laptop")
       givenAnExistingDocument(document1)
       givenAnExistingDocument(document2)
 
       await(repository.get(SimpleSearch(Some("FOUNTAIN"), imagesOnly = false, 1, 100))).results shouldBe Seq(document1)
-      await(repository.get(SimpleSearch(Some("lapTOP"), imagesOnly   = false, 1, 100))).results shouldBe Seq(document2)
+      await(repository.get(SimpleSearch(Some("lapTOP"), imagesOnly = false, 1, 100))).results shouldBe Seq(document2)
     }
 
     "Retrieve Multiple - by Goods Description - word stems" in {
-      // Given
       val document1 = Ruling(reference = "ref1", "0", clock.instant(), nextMonth, "justification", "exacting")
       val document2 = Ruling(reference = "ref2", "0", clock.instant(), tomorrow, "justification", "exactly")
       val document3 = Ruling(reference = "ref3", "0", clock.instant(), tomorrow, "justification", "fountain pen")
@@ -178,26 +192,25 @@ class RulingMongoRepositoryTest
       givenAnExistingDocument(document2)
       givenAnExistingDocument(document3)
 
-      await(repository.get(SimpleSearch(Some("exact"), imagesOnly = false, 1, 100))).results shouldBe Seq(
-        document1,
-        document2
-      )
+      await(repository.get(SimpleSearch(Some("exact"), imagesOnly = false, 1, 100))).results shouldBe
+        Seq(document1, document2)
     }
 
     "Retrieve One - by Goods Description - images only" in {
-      // Given
       val document1 =
         Ruling(
           reference = "ref1",
-          "0",
-          clock.instant(),
-          tomorrow,
-          "justification",
-          "exacting",
+          bindingCommodityCode = "0",
+          effectiveStartDate = clock.instant(),
+          effectiveEndDate = tomorrow,
+          justification = "justification",
+          goodsDescription = "exacting",
           images = Seq("id1, id2")
         )
+
       val document2 = Ruling(reference = "ref2", "0", clock.instant(), tomorrow, "justification", "exactly")
       val document3 = Ruling(reference = "ref3", "0", clock.instant(), tomorrow, "justification", "fountain pen")
+
       givenAnExistingDocument(document1)
       givenAnExistingDocument(document2)
       givenAnExistingDocument(document3)
@@ -205,11 +218,4 @@ class RulingMongoRepositoryTest
       await(repository.get(SimpleSearch(Some("exact"), imagesOnly = true, 1, 100))).results shouldBe Seq(document1)
     }
   }
-
-  private def givenAnExistingDocument(ruling: Ruling): Unit =
-    await(repository.update(ruling, upsert = true))
-
-  private def thenTheDocumentCountShouldBe(count: Int): Unit =
-    await(repository.collection.countDocuments().toFuture()) shouldBe count
-
 }

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/service/FileStoreServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/service/FileStoreServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/service/RulingServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/service/RulingServiceSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/utils/CaseQueueBuilder.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/utils/CaseQueueBuilder.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/utils/DatesSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/utils/DatesSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/utils/GlobalTariffSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/utils/GlobalTariffSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/ErrorViewSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/ErrorViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/ResultSummarySpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/ResultSummarySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/RulingViewSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/RulingViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/SearchResultsViewSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/SearchResultsViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/SearchViewSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/SearchViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/ViewMatchers.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/ViewMatchers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/ViewSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/ViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/PaginationUtilTest.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/PaginationUtilTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/PaginationViewSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/views/components/PaginationViewSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/workers/RulingsWorkerSpec.scala
+++ b/test/unit/uk/gov/hmrc/bindingtariffrulingfrontend/workers/RulingsWorkerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/JsonUtil.scala
+++ b/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/JsonUtil.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/ResourceFiles.scala
+++ b/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/ResourceFiles.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/TestMetrics.scala
+++ b/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/TestMetrics.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/UnitSpec.scala
+++ b/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/UnitSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/WiremockFeatureTestServer.scala
+++ b/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/WiremockFeatureTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/WiremockTestServer.scala
+++ b/test/util/uk/gov/hmrc/bindingtariffrulingfrontend/WiremockTestServer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 HM Revenue & Customs
+ * Copyright 2023 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
There is now a requirement when using Mongo version `x >= 4.4` to have a text filter when using metaTextScore projections and sorts. The sorting wasn't broken but for empty, no word searches the Projections on the query was breaking.
So refactored during a no search scenario to have no projections.

Search for section : **_Text Search Metadata { $meta: "textScore" } Query Requirement_**
https://www.mongodb.com/docs/v6.0/release-notes/4.4-compatibility/#general-changes